### PR TITLE
read any opcua basetype node. No certificate

### DIFF
--- a/examples/readAnyType.go
+++ b/examples/readAnyType.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"io"
+	"log"
+	"time"
+
+	"github.com/gopcua/opcua"
+	"github.com/gopcua/opcua/debug"
+	"github.com/gopcua/opcua/ua"
+)
+
+func main() {
+	var (
+		endpoint = flag.String("endpoint", "opc.tcp://localhost:4840", "OPC UA Endpoint URL")
+		nodeID   = flag.String("node", "", "NodeID to read, such as ns=5;i=123")
+		user     = flag.String("user", "", "username for opcua server")
+		pass     = flag.String("pass", "", "password for opcua server")
+	)
+	flag.BoolVar(&debug.Enable, "debug", false, "enable debug logging, meaning see all connection handshakes and stuff")
+	flag.Parse()
+	log.SetFlags(0)
+
+	ctx := context.Background()
+
+	//Get all endpoint
+	endpoints, err := opcua.GetEndpoints(ctx, *endpoint)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	//Select an endpoint that has security policy None and security mode None
+	ep, err := opcua.SelectEndpoint(endpoints, "None", ua.MessageSecurityModeFromString("None"))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	//Make the connection settings
+	connectionOptions := []opcua.Option{
+		opcua.SecurityPolicy("None"),
+		opcua.SecurityModeString("None"),
+		opcua.SecurityMode(ua.MessageSecurityModeNone),
+		opcua.AuthUsername(*user, *pass),
+		opcua.SecurityFromEndpoint(ep, ua.UserTokenTypeUserName),
+	}
+
+	c, err := opcua.NewClient(*endpoint, connectionOptions...)
+	if err != nil {
+		log.Fatal(err)
+	}
+	if err := c.Connect(ctx); err != nil {
+		log.Fatal(err)
+	}
+	defer c.Close(ctx)
+
+	//parse node id to see if it is based on numeric, string or guid. meaning if:
+	// ns=....;i=...
+	// or ns=...;s=...
+	// or ns=...;g=...
+	id, err := ua.ParseNodeID(*nodeID)
+	if err != nil {
+		log.Fatalf("invalid node id: %v", err)
+	}
+
+	//send a generic read request
+	req := &ua.ReadRequest{
+		MaxAge: 2000,
+		NodesToRead: []*ua.ReadValueID{
+			{NodeID: id},
+		},
+		TimestampsToReturn: ua.TimestampsToReturnBoth,
+	}
+
+	//get response
+	var resp *ua.ReadResponse
+	for {
+		resp, err = c.Read(ctx, req)
+		if err == nil {
+			break
+		}
+
+		// Following switch contains known errors that can be retried by the user.
+		// Best practice is to do it on read operations.
+		switch {
+		case err == io.EOF && c.State() != opcua.Closed:
+			// has to be retried unless user closed the connection
+			time.After(1 * time.Second)
+			continue
+
+		case errors.Is(err, ua.StatusBadSessionIDInvalid):
+			// Session is not activated has to be retried. Session will be recreated internally.
+			time.After(1 * time.Second)
+			continue
+
+		case errors.Is(err, ua.StatusBadSessionNotActivated):
+			// Session is invalid has to be retried. Session will be recreated internally.
+			time.After(1 * time.Second)
+			continue
+
+		case errors.Is(err, ua.StatusBadSecureChannelIDInvalid):
+			// secure channel will be recreated internally.
+			time.After(1 * time.Second)
+			continue
+
+		default:
+			log.Fatalf("Read failed: %s", err)
+		}
+	}
+
+	if resp != nil && resp.Results[0].Status != ua.StatusOK {
+		log.Fatalf("Status not OK: %v", resp.Results[0].Status)
+	}
+
+	//response is variant, as we cant know what was dataType of node; int, bool, or what...
+	//this does not work for structs
+	log.Printf("%#v", resp.Results[0].Value.Value())
+}

--- a/examples/sample.txt
+++ b/examples/sample.txt
@@ -1,0 +1,5 @@
+PS C:\Users\ianko\OneDrive\Documents\GitHub\goTOV\examples> go run .\readAnyType.go -node "ns=4;s=MAIN.count" -user "ok" -pass "ok"                    
+-25445
+PS C:\Users\ianko\OneDrive\Documents\GitHub\goTOV\examples> go run .\readAnyType.go -node "i=2258" -user "ok" -pass "ok"                               
+time.Date(2025, time.November, 2, 11, 29, 2, 646832500, time.UTC)
+PS C:\Users\ianko\OneDrive\Documents\GitHub\goTOV\examples> 


### PR DESCRIPTION
Hey,

here is a compact program to read any type of base node (INT, BOOL, TIME...).

Check the sample.txt to see how is the program called using it's flags.

 The sample does not use certificate file, as beckhoff opcua server enables to have security policy and mode of None. Well at least OPCUA 4.4.7... enables it :) I usually went without certificates for opcua and relied on VPN to secure everything that goes between my app and ot. If you need certificates we can also add them. 
 
 I based this sample on:
 https://github.com/gopcua/opcua/blob/main/examples/read/read.go
 