### PR TITLE
feat: delete fermentation plan API

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,30 @@
+# Default configuration for goTOV.
+# This file is copied to config.yaml inside the Docker image.
+# All values can be overridden by environment variables.
+# For example, `opcua.endpoint` can be set by the env var `GOTOV_OPCUA_ENDPOINT`.
+
+opcua:
+  endpoint: "opc.tcp://192.168.10.150:4840"
+  username: "Administrator"
+  password: "9R3NzPjy"
+
+logging:
+  level: "info" # "debug" is also a good option
+
+server:
+  listen_addr: ":8085"
+
+fermentation:
+  enabled: true
+  database_path: "data/fermentation.db" # Path inside the container
+
+  hysteresis:
+    cooling: 0.3
+    heating: 0.3
+
+  step_check_interval: "30s"
+  stabilization_time: "10m"
+
+brewfather:
+  user_id: "" # Your Brewfather User ID
+  api_key: "" # Your Brewfather API Key

--- a/internal/api/fermentation.go
+++ b/internal/api/fermentation.go
@@ -2,9 +2,12 @@ package api
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
+	"strconv"
 
 	"github.com/MrBoggi/goTOV/internal/fermentation"
+	"github.com/go-chi/chi/v5"
 )
 
 type StartFermentationRequest struct {
@@ -84,6 +87,32 @@ func (s *Server) handleStartFermentation(w http.ResponseWriter, r *http.Request)
 	})
 }
 
+func (s *Server) handleDeleteFermentationPlan(w http.ResponseWriter, r *http.Request) {
+	idStr := chi.URLParam(r, "id")
+	id, err := strconv.ParseInt(idStr, 10, 64)
+	if err != nil {
+		http.Error(w, "invalid ID format", http.StatusBadRequest)
+		return
+	}
+
+	err = s.fermentationStore.DeletePlan(id)
+	if err != nil {
+		if errors.Is(err, fermentation.ErrPlanNotFound) {
+			http.Error(w, "plan not found", http.StatusNotFound)
+			return
+		}
+		if errors.Is(err, fermentation.ErrPlanInUse) {
+			http.Error(w, "cannot delete plan while in use by an active fermentation", http.StatusConflict)
+			return
+		}
+		s.log.Error().Err(err).Int64("id", id).Msg("failed to delete fermentation plan")
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
 func (s *Server) handleGetFermentationStatus(w http.ResponseWriter, r *http.Request) {
 	active, err := s.fermentationStore.ListActiveFermentations()
 	if err != nil {
@@ -106,6 +135,7 @@ func (s *Server) handleGetApiDocs(w http.ResponseWriter, r *http.Request) {
 			{"method": "POST", "path": "/api/fermentation/start", "description": "Start a fermentation process (requires planID, tankID)"},
 			{"method": "GET", "path": "/api/fermentation/status", "description": "Get status of all active fermentations"},
 			{"method": "GET", "path": "/api/fermentation/docs", "description": "This documentation"},
+			{"method": "DELETE", "path": "/api/fermentation/plan/{id}", "description": "Delete a fermentation plan (if not in use)"},
 			{"method": "GET", "path": "/api/tanks", "description": "List available tanks"},
 		},
 	}

--- a/internal/api/ws.go
+++ b/internal/api/ws.go
@@ -67,7 +67,7 @@ func (s *Server) Router() http.Handler {
 
 	r.Use(cors.Handler(cors.Options{
 		AllowedOrigins:   []string{"*"},
-		AllowedMethods:   []string{"GET", "POST", "OPTIONS"},
+		AllowedMethods:   []string{"GET", "POST", "DELETE", "OPTIONS"},
 		AllowedHeaders:   []string{"Accept", "Authorization", "Content-Type", "X-CSRF-Token"},
 		AllowCredentials: false,
 		MaxAge:           300,
@@ -102,6 +102,7 @@ func (s *Server) Router() http.Handler {
 	r.Post("/api/fermentation/start", s.handleStartFermentation)
 	r.Get("/api/fermentation/status", s.handleGetFermentationStatus)
 	r.Get("/api/fermentation/docs", s.handleGetApiDocs)
+	r.Delete("/api/fermentation/plan/{id}", s.handleDeleteFermentationPlan)
 	r.Get("/api/tanks", s.handleListTanks)
 
 	// ----------------------------------------------------

--- a/internal/api/ws_test.go
+++ b/internal/api/ws_test.go
@@ -23,6 +23,7 @@ type MockFermentationStore struct {
 	UpdateStateFunc             func(state fermentation.FermentationState) error
 	ListStepsFunc               func(planID int64) ([]fermentation.FermentationStep, error)
 	ClearFunc                   func() error
+	DeletePlanFunc              func(id int64) error
 }
 
 func (m *MockFermentationStore) SavePlan(plan fermentation.FermentationPlan) (int64, error) {
@@ -81,6 +82,13 @@ func (m *MockFermentationStore) UpdateState(state fermentation.FermentationState
 func (m *MockFermentationStore) Clear() error {
 	if m.ClearFunc != nil {
 		return m.ClearFunc()
+	}
+	return nil
+}
+
+func (m *MockFermentationStore) DeletePlan(id int64) error {
+	if m.DeletePlanFunc != nil {
+		return m.DeletePlanFunc(id)
 	}
 	return nil
 }
@@ -226,4 +234,56 @@ func TestListTanksEndpoint(t *testing.T) {
 	err = json.Unmarshal(rr.Body.Bytes(), &actualTanks)
 	assert.NoError(t, err)
 	assert.Len(t, actualTanks, 2)
+}
+
+func TestDeleteFermentationPlanEndpoint(t *testing.T) {
+	log := logger.New()
+
+	t.Run("Successful Deletion", func(t *testing.T) {
+		mockStore := &MockFermentationStore{
+			DeletePlanFunc: func(id int64) error {
+				assert.Equal(t, int64(123), id)
+				return nil
+			},
+		}
+		server := NewServer(log, nil, mockStore, nil)
+		req, _ := http.NewRequest("DELETE", "/api/fermentation/plan/123", nil)
+		rr := httptest.NewRecorder()
+		server.Router().ServeHTTP(rr, req)
+		assert.Equal(t, http.StatusNoContent, rr.Code)
+	})
+
+	t.Run("Plan In Use Conflict", func(t *testing.T) {
+		mockStore := &MockFermentationStore{
+			DeletePlanFunc: func(id int64) error {
+				return fermentation.ErrPlanInUse
+			},
+		}
+		server := NewServer(log, nil, mockStore, nil)
+		req, _ := http.NewRequest("DELETE", "/api/fermentation/plan/123", nil)
+		rr := httptest.NewRecorder()
+		server.Router().ServeHTTP(rr, req)
+		assert.Equal(t, http.StatusConflict, rr.Code)
+	})
+
+	t.Run("Plan Not Found", func(t *testing.T) {
+		mockStore := &MockFermentationStore{
+			DeletePlanFunc: func(id int64) error {
+				return fermentation.ErrPlanNotFound
+			},
+		}
+		server := NewServer(log, nil, mockStore, nil)
+		req, _ := http.NewRequest("DELETE", "/api/fermentation/plan/999", nil)
+		rr := httptest.NewRecorder()
+		server.Router().ServeHTTP(rr, req)
+		assert.Equal(t, http.StatusNotFound, rr.Code)
+	})
+
+	t.Run("Invalid ID Format", func(t *testing.T) {
+		server := NewServer(log, nil, &MockFermentationStore{}, nil)
+		req, _ := http.NewRequest("DELETE", "/api/fermentation/plan/abc", nil)
+		rr := httptest.NewRecorder()
+		server.Router().ServeHTTP(rr, req)
+		assert.Equal(t, http.StatusBadRequest, rr.Code)
+	})
 }

--- a/internal/fermentation/sqlite_store.go
+++ b/internal/fermentation/sqlite_store.go
@@ -180,6 +180,51 @@ WHERE id = :id`,
 	return err
 }
 
+func (s *SQLiteStore) DeletePlan(id int64) error {
+	// 1. Check if plan exists
+	var exists bool
+	err := s.DB.Get(&exists, "SELECT EXISTS(SELECT 1 FROM fermentation_plans WHERE id = ?)", id)
+	if err != nil {
+		return fmt.Errorf("check plan existence: %w", err)
+	}
+	if !exists {
+		return ErrPlanNotFound
+	}
+
+	// 2. Check if plan is in use
+	var inUse bool
+	err = s.DB.Get(&inUse, "SELECT EXISTS(SELECT 1 FROM fermentation_states WHERE plan_id = ? AND status = ?)", id, StatusRunning)
+	if err != nil {
+		return fmt.Errorf("check if plan in use: %w", err)
+	}
+	if inUse {
+		return ErrPlanInUse
+	}
+
+	// 3. Delete plan and steps in transition
+	tx, err := s.DB.Beginx()
+	if err != nil {
+		return fmt.Errorf("begin transaction: %w", err)
+	}
+	defer func() {
+		_ = tx.Rollback()
+	}()
+
+	// Delete steps first
+	_, err = tx.Exec("DELETE FROM fermentation_steps WHERE plan_id = ?", id)
+	if err != nil {
+		return fmt.Errorf("delete steps: %w", err)
+	}
+
+	// Delete plan
+	_, err = tx.Exec("DELETE FROM fermentation_plans WHERE id = ?", id)
+	if err != nil {
+		return fmt.Errorf("delete plan: %w", err)
+	}
+
+	return tx.Commit()
+}
+
 func (s *SQLiteStore) Clear() error {
 	_, err := s.DB.Exec("DELETE FROM fermentation_steps; DELETE FROM fermentation_states; DELETE FROM fermentation_plans;")
 	return err

--- a/internal/fermentation/store.go
+++ b/internal/fermentation/store.go
@@ -1,11 +1,21 @@
 package fermentation
 
+import (
+	"errors"
+)
+
+var (
+	ErrPlanInUse    = errors.New("cannot delete plan while in use by an active fermentation")
+	ErrPlanNotFound = errors.New("fermentation plan not found")
+)
+
 type FermentationStore interface {
 	SavePlan(plan FermentationPlan) (int64, error)
 	GetPlan(id int64) (FermentationPlan, error)
 	GetSteps(planID int64) ([]FermentationStep, error)
 	ListSteps(planID int64) ([]FermentationStep, error)
 	ListPlans() ([]FermentationPlan, error)
+	DeletePlan(id int64) error
 	StartFermentation(planID int64, tankID string) (int64, error)
 	ListActiveFermentations() ([]FermentationState, error)
 	UpdateState(state FermentationState) error


### PR DESCRIPTION
This PR adds a new endpoint to delete fermentation plans.

### Features:
- **DELETE /api/fermentation/plan/{id}**: New endpoint for removing plans.
- **CORS Update**: Enabled DELETE method in chi/cors config to resolve frontend preflight issues.
- **Safety Checks**: The API returns 409 Conflict if a plan is currently in use by an active fermentation.
- **Cascaded Delete**: Associated fermentation steps are cleared automatically within a database transaction.
- **Self-Documentation**: The /api/fermentation/docs endpoint is updated to include the new route.

### Verification:
- Added comprehensive unit tests in internal/api/ws_test.go covering success, conflict (409), and not found (404) scenarios.
- Verified with go test and golangci-lint.