### PR TITLE
fix: drop legacy tank_no column causing NOT NULL constraint failures

### DIFF
--- a/internal/fermentation/sqlite_store.go
+++ b/internal/fermentation/sqlite_store.go
@@ -100,6 +100,15 @@ CREATE TABLE IF NOT EXISTS fermentation_states (
 		}
 	}
 
+	// Check for legacy tank_no column in fermentation_states (can cause NOT NULL constraint failures)
+	err = s.DB.Get(&count, "SELECT count(*) FROM pragma_table_info('fermentation_states') WHERE name='tank_no'")
+	if err == nil && count > 0 {
+		_, err = s.DB.Exec("ALTER TABLE fermentation_states DROP COLUMN tank_no")
+		if err != nil {
+			return fmt.Errorf("failed to drop legacy tank_no column: %w", err)
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
This PR fixes a critical 500 API error caused by a leftover \	ank_no\ column in the \ermentation_states\ table.

- Older versions of the database had a \	ank_no\ column with a \NOT NULL\ constraint. 
- When \	ank_id\ was introduced, \	ank_no\ was left behind, causing \INSERT\ operations to fail on older database instances.
- Added a migration step to \sqlite_store.go\ that checks for and safely drops the \	ank_no\ column.