### PR TITLE
fix: stop fermentations directly in store before plan deletion

### DIFF
--- a/internal/api/fermentation.go
+++ b/internal/api/fermentation.go
@@ -135,15 +135,20 @@ func (s *Server) handleDeleteFermentationPlan(w http.ResponseWriter, r *http.Req
 	}
 
 	// If force=true, stop all active fermentations using this plan first
-	if r.URL.Query().Get("force") == "true" && s.engine != nil {
+	if r.URL.Query().Get("force") == "true" {
 		active, listErr := s.fermentationStore.ListActiveFermentations()
 		if listErr == nil {
 			for _, a := range active {
 				if a.PlanID == id {
-					if stopErr := s.engine.StopFermentation(a.ID); stopErr != nil {
-						s.log.Error().Err(stopErr).Int64("fermentationID", a.ID).Msg("failed to stop fermentation before plan deletion")
+					// Stop in store (DB) first — this is the source of truth for DeletePlan
+					if stopErr := s.fermentationStore.StopFermentation(a.ID); stopErr != nil {
+						s.log.Error().Err(stopErr).Int64("fermentationID", a.ID).Msg("failed to stop fermentation in store before plan deletion")
 					} else {
-						s.log.Info().Int64("fermentationID", a.ID).Str("tank", a.TankID).Msg("stopped fermentation before plan deletion")
+						s.log.Info().Int64("fermentationID", a.ID).Str("tank", a.TankID).Msg("stopped fermentation in store before plan deletion")
+					}
+					// Also remove from engine's in-memory map if engine is running
+					if s.engine != nil {
+						s.engine.RemoveFermentation(a.ID)
 					}
 				}
 			}

--- a/internal/fermentation/engine.go
+++ b/internal/fermentation/engine.go
@@ -74,6 +74,15 @@ func (e *Engine) AddFermentation(state *FermentationState) {
 	e.log.Info().Int64("id", state.ID).Msg("➕ Added fermentation to engine")
 }
 
+// RemoveFermentation removes a fermentation from the engine's in-memory active map
+// without touching the database. Use this when the DB has already been updated.
+func (e *Engine) RemoveFermentation(id int64) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	delete(e.active, id)
+	e.log.Info().Int64("id", id).Msg("➖ Removed fermentation from engine map")
+}
+
 func (e *Engine) StopFermentation(id int64) error {
 	e.mu.Lock()
 	state, ok := e.active[id]


### PR DESCRIPTION
engine.StopFermentation could fail if the fermentation wasn't in the engine's in-memory active map (e.g. after container restart), leaving DB status as RUNNING and causing DeletePlan to still return ErrPlanInUse.

Now we call store.StopFermentation directly (DB update first), then clean up the engine map via the new RemoveFermentation method.