### PR TITLE
fix: add SQLiteTime type to handle time scanning from modernc.org/sqlite

### DIFF
--- a/internal/api/fermentation.go
+++ b/internal/api/fermentation.go
@@ -136,15 +136,19 @@ func (s *Server) handleDeleteFermentationPlan(w http.ResponseWriter, r *http.Req
 
 	// If force=true, stop all active fermentations using this plan first
 	if r.URL.Query().Get("force") == "true" {
+		s.log.Info().Int64("planID", id).Msg("force-delete: stopping active fermentations for plan")
 		active, listErr := s.fermentationStore.ListActiveFermentations()
-		if listErr == nil {
+		if listErr != nil {
+			s.log.Error().Err(listErr).Int64("planID", id).Msg("force-delete: failed to list active fermentations")
+		} else {
+			s.log.Info().Int64("planID", id).Int("activeCount", len(active)).Msg("force-delete: found active fermentations")
 			for _, a := range active {
 				if a.PlanID == id {
 					// Stop in store (DB) first — this is the source of truth for DeletePlan
 					if stopErr := s.fermentationStore.StopFermentation(a.ID); stopErr != nil {
-						s.log.Error().Err(stopErr).Int64("fermentationID", a.ID).Msg("failed to stop fermentation in store before plan deletion")
+						s.log.Error().Err(stopErr).Int64("fermentationID", a.ID).Msg("force-delete: failed to stop fermentation in store")
 					} else {
-						s.log.Info().Int64("fermentationID", a.ID).Str("tank", a.TankID).Msg("stopped fermentation in store before plan deletion")
+						s.log.Info().Int64("fermentationID", a.ID).Str("tank", a.TankID).Msg("force-delete: stopped fermentation in store")
 					}
 					// Also remove from engine's in-memory map if engine is running
 					if s.engine != nil {

--- a/internal/fermentation/engine.go
+++ b/internal/fermentation/engine.go
@@ -201,7 +201,7 @@ func (e *Engine) processOne(state *FermentationState) (bool, error) {
 	currentStep := steps[state.StepIndex]
 
 	// 2. Check if step duration is finished
-	elapsed := time.Since(state.StepStartedAt).Hours()
+	elapsed := time.Since(state.StepStartedAt.Time).Hours()
 	if elapsed >= currentStep.DurationHours {
 		e.log.Info().
 			Int64("id", state.ID).
@@ -210,7 +210,7 @@ func (e *Engine) processOne(state *FermentationState) (bool, error) {
 			Msg("⏭️ Advancing to next fermentation step")
 
 		state.StepIndex++
-		state.StepStartedAt = time.Now().UTC()
+		state.StepStartedAt = SQLiteTime{time.Now().UTC()}
 
 		if state.StepIndex < len(steps) {
 			state.TargetTemp = steps[state.StepIndex].Temperature

--- a/internal/fermentation/sqlite_store.go
+++ b/internal/fermentation/sqlite_store.go
@@ -188,7 +188,7 @@ func (s *SQLiteStore) StartFermentation(planID int64, tankID string, batchID str
 		return 0, fmt.Errorf("get steps for starting fermentation: %w", err)
 	}
 
-	now := time.Now().UTC()
+	now := SQLiteTime{time.Now().UTC()}
 	state := FermentationState{
 		PlanID:        planID,
 		TankID:        tankID,

--- a/internal/fermentation/types.go
+++ b/internal/fermentation/types.go
@@ -1,6 +1,66 @@
 package fermentation
 
-import "time"
+import (
+	"database/sql/driver"
+	"fmt"
+	"time"
+)
+
+// SQLiteTime wraps time.Time to handle scanning from SQLite string columns.
+// modernc.org/sqlite stores timestamps as strings; database/sql cannot scan
+// them into *time.Time directly.
+type SQLiteTime struct {
+	time.Time
+}
+
+// sqliteTimeFormats lists formats we may encounter in the database.
+var sqliteTimeFormats = []string{
+	time.RFC3339Nano,
+	time.RFC3339,
+	"2006-01-02 15:04:05.999999999-07:00",
+	"2006-01-02T15:04:05.999999999-07:00",
+	"2006-01-02 15:04:05.999999999",
+	"2006-01-02T15:04:05.999999999",
+	"2006-01-02 15:04:05",
+	"2006-01-02T15:04:05",
+	"2006-01-02 15:04:05Z",
+	"2006-01-02T15:04:05Z",
+}
+
+func (st *SQLiteTime) Scan(value interface{}) error {
+	if value == nil {
+		st.Time = time.Time{}
+		return nil
+	}
+	switch v := value.(type) {
+	case time.Time:
+		st.Time = v
+		return nil
+	case string:
+		for _, format := range sqliteTimeFormats {
+			if t, err := time.Parse(format, v); err == nil {
+				st.Time = t
+				return nil
+			}
+		}
+		return fmt.Errorf("cannot parse SQLite time string: %q", v)
+	case []byte:
+		s := string(v)
+		for _, format := range sqliteTimeFormats {
+			if t, err := time.Parse(format, s); err == nil {
+				st.Time = t
+				return nil
+			}
+		}
+		return fmt.Errorf("cannot parse SQLite time bytes: %q", s)
+	default:
+		return fmt.Errorf("unsupported SQLiteTime scan type: %T", value)
+	}
+}
+
+func (st SQLiteTime) Value() (driver.Value, error) {
+	return st.Time.UTC().Format(time.RFC3339Nano), nil
+}
 
 // Et enkelt steg i en plan vi LAGRER i SQLite.
 type FermentationStep struct {
@@ -30,15 +90,15 @@ const (
 
 // Til bruk av prosessmotoren (kommer senere)
 type FermentationState struct {
-	ID            int64     `db:"id" json:"id"`
-	PlanID        int64     `db:"plan_id" json:"planID"`
-	PlanName      string    `db:"-" json:"planName,omitempty"` // 👈 For UI display
-	TankID        string    `db:"tank_id" json:"tankID"`
-	BatchID       string    `db:"batch_id" json:"batchID"`
-	StepIndex     int       `db:"step_index" json:"stepIndex"`
-	StartedAt     time.Time `db:"started_at" json:"startedAt"`
-	StepStartedAt time.Time `db:"step_started_at" json:"stepStartedAt"`
-	StepDuration  float64   `db:"-" json:"stepDuration,omitempty"` // 👈 Hours
-	TargetTemp    float64   `db:"target_temp" json:"targetTemp"`
-	Status        string    `db:"status" json:"status"`
+	ID            int64      `db:"id" json:"id"`
+	PlanID        int64      `db:"plan_id" json:"planID"`
+	PlanName      string     `db:"-" json:"planName,omitempty"`
+	TankID        string     `db:"tank_id" json:"tankID"`
+	BatchID       string     `db:"batch_id" json:"batchID"`
+	StepIndex     int        `db:"step_index" json:"stepIndex"`
+	StartedAt     SQLiteTime `db:"started_at" json:"startedAt"`
+	StepStartedAt SQLiteTime `db:"step_started_at" json:"stepStartedAt"`
+	StepDuration  float64    `db:"-" json:"stepDuration,omitempty"`
+	TargetTemp    float64    `db:"target_temp" json:"targetTemp"`
+	Status        string     `db:"status" json:"status"`
 }


### PR DESCRIPTION
## Root Cause The modernc.org/sqlite driver returns timestamp columns as strings, but Go's database/sql cannot scan strings into *time.Time. This caused ListActiveFermentations() and engine.Restore() to fail on container startup with: ` unsupported Scan, storing driver.Value type string into type *time.Time ` This was the **real** reason ?force=true still returned 409: the ListActiveFermentations call in the force-delete handler failed, skipping the stop logic entirely. ## Changes - **types.go**: New SQLiteTime type with Scanner/Valuer interfaces supporting multiple timestamp formats - **types.go**: FermentationState now uses SQLiteTime for StartedAt and StepStartedAt - **engine.go**: Updated to use SQLiteTime - **sqlite_store.go**: Updated to use SQLiteTime - **fermentation.go**: Extended logging in force-delete handler