### PR TITLE
fix: add Go time.Time.String() format to SQLiteTime parser

### DIFF
--- a/internal/fermentation/types.go
+++ b/internal/fermentation/types.go
@@ -15,6 +15,8 @@ type SQLiteTime struct {
 
 // sqliteTimeFormats lists formats we may encounter in the database.
 var sqliteTimeFormats = []string{
+	"2006-01-02 15:04:05.999999999 +0000 UTC", // Go time.Time.String() format
+	"2006-01-02 15:04:05.999999999 -0700 MST", // Go time.Time.String() with named timezone
 	time.RFC3339Nano,
 	time.RFC3339,
 	"2006-01-02 15:04:05.999999999-07:00",


### PR DESCRIPTION
The existing sqliteTimeFormats list did not include Go's native time.Time.String() format: '2006-01-02 15:04:05.999999999 +0000 UTC'. This is the format sqlx uses when writing time.Time values to SQLite, causing ListActiveFermentations and Restore to fail on read.