### PR TITLE
fix: standardize JSON tags to camelCase for UI coordination

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,8 @@ Welcome to **goTOV** (Go Tæsse Øl Verksted). You are assisting in the developm
     - **Error Handling**: Never ignore errors (`_`). Wrap with context: `fmt.Errorf("context: %w", err)`.
     - **Context**: Pass `context.Context` as the first argument for I/O and PLC calls.
     - **Concurrency**: Use standard patterns (Channels, WaitGroups) for real-time tag updates.
+    - **JSON Naming**: Always use **camelCase** for JSON tags in structs. Suffixes like "ID" should be lowercase "id" (e.g., `batchId`, `planId`).
+    - **API Documentation**: Update `handleGetApiDocs` when adding or changing endpoints. Ensure JSON keys in responses match the struct tags.
 
 ### 2. Git Workflow (MANDATORY)
 - **Base Branch**: `development`.

--- a/internal/api/fermentation.go
+++ b/internal/api/fermentation.go
@@ -11,14 +11,14 @@ import (
 )
 
 type StartFermentationRequest struct {
-	PlanID  int64  `json:"planID"`
-	TankID  string `json:"tankID"`
-	BatchID string `json:"batchID"`
+	PlanID  int64  `json:"planId"`
+	TankID  string `json:"tankId"`
+	BatchID string `json:"batchId"`
 }
 
 type StopFermentationRequest struct {
 	ID     int64  `json:"id"`
-	TankID string `json:"tankID"`
+	TankID string `json:"tankId"`
 }
 
 func (s *Server) handleSaveFermentationPlan(w http.ResponseWriter, r *http.Request) {
@@ -64,6 +64,12 @@ func (s *Server) handleStartFermentation(w http.ResponseWriter, r *http.Request)
 		http.Error(w, "invalid JSON", http.StatusBadRequest)
 		return
 	}
+
+	s.log.Debug().
+		Int64("planId", req.PlanID).
+		Str("tankId", req.TankID).
+		Str("batchId", req.BatchID).
+		Msg("🚀 Received start fermentation request")
 
 	fermentationID, err := s.fermentationStore.StartFermentation(req.PlanID, req.TankID, req.BatchID)
 	if err != nil {

--- a/internal/fermentation/types.go
+++ b/internal/fermentation/types.go
@@ -66,20 +66,20 @@ func (st SQLiteTime) Value() (driver.Value, error) {
 
 // Et enkelt steg i en plan vi LAGRER i SQLite.
 type FermentationStep struct {
-	StepNumber    int     `db:"step_number" json:"step_number"`
+	StepNumber    int     `db:"step_number" json:"stepNumber"`
 	Temperature   float64 `db:"temperature" json:"temperature"`
-	DurationHours float64 `db:"duration_hours" json:"duration_hours"`
+	DurationHours float64 `db:"duration_hours" json:"durationHours"`
 	Description   string  `db:"description" json:"description"`
 	Type          string  `db:"type" json:"type"`
 }
 
 // Selve planen – én plan per recipe.
 type FermentationPlan struct {
-	ID         int64              `db:"id"`
-	Name       string             `db:"name"`
-	RecipeID   string             `db:"recipe_id"`
-	TotalSteps int                `db:"total_steps"`
-	Steps      []FermentationStep `db:"-"` // hentes separat
+	ID         int64              `db:"id" json:"id"`
+	Name       string             `db:"name" json:"name"`
+	RecipeID   string             `db:"recipe_id" json:"recipeId"`
+	TotalSteps int                `db:"total_steps" json:"totalSteps"`
+	Steps      []FermentationStep `db:"-" json:"steps,omitempty"` // hentes separat
 }
 
 const (
@@ -93,10 +93,10 @@ const (
 // Til bruk av prosessmotoren (kommer senere)
 type FermentationState struct {
 	ID            int64      `db:"id" json:"id"`
-	PlanID        int64      `db:"plan_id" json:"planID"`
+	PlanID        int64      `db:"plan_id" json:"planId"`
 	PlanName      string     `db:"-" json:"planName,omitempty"`
-	TankID        string     `db:"tank_id" json:"tankID"`
-	BatchID       string     `db:"batch_id" json:"batchID"`
+	TankID        string     `db:"tank_id" json:"tankId"`
+	BatchID       string     `db:"batch_id" json:"batchId"`
 	StepIndex     int        `db:"step_index" json:"stepIndex"`
 	StartedAt     SQLiteTime `db:"started_at" json:"startedAt"`
 	StepStartedAt SQLiteTime `db:"step_started_at" json:"stepStartedAt"`


### PR DESCRIPTION
## Problem
The UI displayed "BN/A" (Batch N/A) for active fermentations because of inconsistent JSON naming between the frontend and backend. Specifically, the backend used `batchID` while the frontend likely sent/expected `batchId`.

## Solution
1. **Standardization**: Updated all structs in `internal/fermentation/types.go` and `internal/api/fermentation.go` to use strictly camelCase JSON tags with a small `id` (e.g., `batchId`, `planId`). This follows standard JavaScript/TypeScript conventions.
2. **Robustness**: Added missing JSON tags to all models (`FermentationPlan`, `FermentationStep`).
3. **Observability**: Added debug logging to the start fermentation endpoint to track exactly what values are received from the UI.
4. **Governance**: Updated `AGENTS.md` with strict JSON naming rules for future development.

## Actions required
- The frontend team must be notified to align their keys with this standard.
- A coordination prompt has been prepared in `frontend_coordination_prompt_bna.md`.
