### PR TITLE
feat: implement duty-cycle based glycol load calculation

### DIFF
--- a/internal/api/glycol.go
+++ b/internal/api/glycol.go
@@ -32,18 +32,10 @@ func (s *Server) handleGetGlycolStatus(w http.ResponseWriter, r *http.Request) {
 	// Set static values for now as per instructions
 	status.Pressure = nil
 
-	// Read pump status to set load percentage:
-	// If pump is active, return 100%, else 0%
+	// Read load percentage from engine (calculated duty cycle over last 1 min)
 	status.LoadPercentage = 0.0
-	if s.client != nil {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
-		val, err := s.client.ReadNodeValue(ctx, "ns=4;s=MAIN.fbUA.glykolkjolerPumpe")
-		if err == nil {
-			if pumpOk, ok := val.(bool); ok && pumpOk {
-				status.LoadPercentage = 100.0
-			}
-		}
+	if s.engine != nil {
+		status.LoadPercentage = s.engine.GetGlycolLoad()
 	}
 
 	// Fetch history from the last 24 hours

--- a/internal/fermentation/engine.go
+++ b/internal/fermentation/engine.go
@@ -20,15 +20,24 @@ type Engine struct {
 
 	mu     sync.RWMutex
 	active map[int64]*FermentationState
+
+	// Glycol load tracking
+	glycolMu            sync.Mutex
+	pumpLastState       bool
+	pumpOnSince         time.Time
+	pumpAccumulatedTime time.Duration
+	lastGlycolLogTime   time.Time
+	currentGlycolLoad   float64
 }
 
 func NewEngine(store FermentationStore, client *opcua.Client, log zerolog.Logger) *Engine {
 	return &Engine{
-		store:  store,
-		client: client,
-		log:    log,
-		stop:   make(chan struct{}),
-		active: make(map[int64]*FermentationState),
+		store:             store,
+		client:            client,
+		log:               log,
+		stop:              make(chan struct{}),
+		active:            make(map[int64]*FermentationState),
+		lastGlycolLogTime: time.Now(),
 	}
 }
 
@@ -211,6 +220,32 @@ func (e *Engine) processAll() {
 			e.log.Error().Err(err).Msg("failed to sync glycol pump")
 		}
 	}
+
+	// Track pump duration for duty-cycle calculation
+	e.updatePumpTracking(anyCooling)
+}
+
+func (e *Engine) updatePumpTracking(isCurrentlyOn bool) {
+	e.glycolMu.Lock()
+	defer e.glycolMu.Unlock()
+
+	now := time.Now()
+	if isCurrentlyOn {
+		if !e.pumpLastState {
+			// Turned ON
+			e.pumpOnSince = now
+		} else {
+			// Stayed ON - accumulate duration since last check
+			e.pumpAccumulatedTime += now.Sub(e.pumpOnSince)
+			e.pumpOnSince = now
+		}
+	} else {
+		if e.pumpLastState {
+			// Turned OFF - record final bit of duration
+			e.pumpAccumulatedTime += now.Sub(e.pumpOnSince)
+		}
+	}
+	e.pumpLastState = isCurrentlyOn
 }
 
 func (e *Engine) logGlycol() {
@@ -247,16 +282,45 @@ func (e *Engine) logGlycol() {
 		return
 	}
 
-	// For now, load is 0 and pressure is 0 as per user instructions
-	load := 0.0
+	// Calculate duty cycle since last log
+	e.glycolMu.Lock()
+	now := time.Now()
+
+	// If pump is currently on, add the time since it started/was last checked
+	if e.pumpLastState {
+		e.pumpAccumulatedTime += now.Sub(e.pumpOnSince)
+		e.pumpOnSince = now
+	}
+
+	totalInterval := now.Sub(e.lastGlycolLogTime)
+	var load float64
+	if totalInterval > 0 {
+		load = (float64(e.pumpAccumulatedTime) / float64(totalInterval)) * 100.0
+	}
+	if load > 100 {
+		load = 100
+	}
+
+	e.currentGlycolLoad = load
+	e.pumpAccumulatedTime = 0
+	e.lastGlycolLogTime = now
+	e.glycolMu.Unlock()
+
 	pressureValue := 0.0
 	pressure := &pressureValue
 
 	if err := e.store.LogGlycolData(temp, pressure, load); err != nil {
 		e.log.Error().Err(err).Msg("failed to log glycol history")
 	} else {
-		e.log.Debug().Float64("temp", temp).Msg("📊 Logged glycol history data")
+		e.log.Debug().Float64("temp", temp).Float64("load", load).Msg("📊 Logged glycol history data")
 	}
+}
+
+// GetGlycolLoad returns the last calculated duty-cycle load percentage
+func (e *Engine) GetGlycolLoad() float64 {
+	e.glycolMu.Lock()
+	defer e.glycolMu.Unlock()
+	return e.currentGlycolLoad
 }
 
 func (e *Engine) processOne(state *FermentationState) (bool, error) {


### PR DESCRIPTION
# Glycol Duty-Cycle Last-beregning (PR #28)

Dette arbeidet bygger videre på det nylig mergede Glykol-APIet (PR #27) og introduserer mer nøyaktig sporing av systembelastning.

## Endringer i PR #28

1. **Duty-Cycle Sporing (`internal/fermentation/engine.go`)**
   - Introdusert logikk i `Engine` som overvåker nøyaktig når glykolpumpen skrus på/av.
   - Beregner `loadPercentage` som en glidende duty-cycle over hvert 1-minutts loggeintervall.
   - Dette erstatter den tidligere 0/100 statusen med en reell prosentverdi (f.eks. hvis pumpen har vært på 30 sekunder av et minutt, logges 50% belastning).

2. **API Oppdatering (`internal/api/glycol.go`)**
   - Endret `/api/glycol/status` til å returnere den beregnede duty-cycle verdien fra motoren i stedet for en øyeblikksverdi av pumpen.

## Verifisering
- Enhetstester for API og Engine er kjørt og passerer.
- Koden er formatert iht. prosjektstandard (`gofmt`).
- PR #28 er nå oppdatert med denne beskrivelsen og inneholder kun nødvendige kildekodeendringer.
