### PR TITLE
feat: implement brew starting and logging backend

### DIFF
--- a/internal/api/brewing.go
+++ b/internal/api/brewing.go
@@ -1,0 +1,119 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/MrBoggi/goTOV/internal/brew"
+)
+
+type StartBrewingRequest struct {
+	Type    string `json:"type"` // "manual" or "brewfather"
+	BatchID string `json:"batchId,omitempty"`
+}
+
+func (s *Server) handleListBrewfatherBatches(w http.ResponseWriter, r *http.Request) {
+	if s.brewfatherClient == nil {
+		http.Error(w, "Brewfather client not configured", http.StatusServiceUnavailable)
+		return
+	}
+
+	batches, err := s.brewfatherClient.FetchBatches()
+	if err != nil {
+		s.log.Error().Err(err).Msg("Failed to fetch batches from Brewfather")
+		http.Error(w, "Failed to fetch batches", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(batches); err != nil {
+		s.log.Error().Err(err).Msg("Failed to encode batches")
+	}
+}
+
+func (s *Server) handleStartBrewing(w http.ResponseWriter, r *http.Request) {
+	var req StartBrewingRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid request", http.StatusBadRequest)
+		return
+	}
+
+	session := &brew.BrewingSession{
+		ID:        "session-" + time.Now().Format("20060102150405"),
+		StartTime: time.Now(),
+		Status:    req.Type,
+		BatchID:   req.BatchID,
+	}
+
+	if req.Type == "manual" {
+		session.RecipeName = "Manual Brew"
+	} else if req.Type == "brewfather" {
+		// Fetch batch details if needed
+		session.RecipeName = "Brewfather Batch " + req.BatchID
+	}
+
+	s.brewingEngine.StartSession(session)
+
+	// Persist to DB
+	data, _ := json.Marshal(session)
+	_ = s.brewhouseStore.SaveBrewingSession(string(data))
+
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(session)
+}
+
+func (s *Server) handleStopBrewing(w http.ResponseWriter, r *http.Request) {
+	session := s.brewingEngine.GetSession()
+	if session == nil {
+		http.Error(w, "No active session", http.StatusNotFound)
+		return
+	}
+
+	// Log to DB
+	data, _ := json.Marshal(session)
+	_ = s.brewhouseStore.LogBrewingSession(string(data))
+
+	// Clear active session in DB
+	_ = s.brewhouseStore.SaveBrewingSession("")
+
+	s.brewingEngine.StopSession()
+	w.WriteHeader(http.StatusOK)
+}
+
+func (s *Server) handleGetBrewingStatus(w http.ResponseWriter, r *http.Request) {
+	session := s.brewingEngine.GetSession()
+	if session == nil {
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(session)
+}
+
+func (s *Server) broadcastBrewingStatus() {
+	ticker := time.NewTicker(1 * time.Second)
+	defer ticker.Stop()
+
+	for range ticker.C {
+		session := s.brewingEngine.GetSession()
+		if session == nil {
+			continue
+		}
+
+		msg := WSMessage{
+			Tag:         "BREWING_STATUS",
+			DisplayName: "Brewing Status",
+			Value:       session,
+			ValueType:   "BrewingSession",
+			Timestamp:   time.Now().UnixMilli(),
+		}
+
+		s.latestMu.Lock()
+		s.latest[msg.Tag] = msg
+		s.latestMu.Unlock()
+
+		s.broadcast(msg)
+	}
+}

--- a/internal/api/ws.go
+++ b/internal/api/ws.go
@@ -8,6 +8,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/MrBoggi/goTOV/internal/brew"
+	"github.com/MrBoggi/goTOV/internal/brewfather"
 	"github.com/MrBoggi/goTOV/internal/brewhouse"
 	"github.com/MrBoggi/goTOV/internal/fermentation"
 	"github.com/MrBoggi/goTOV/internal/opcua"
@@ -25,6 +27,8 @@ type Server struct {
 	engine            *fermentation.Engine
 	brewhouseStore    brewhouse.Store
 	brewhouseEngine   *brewhouse.Engine
+	brewingEngine     *brew.Engine
+	brewfatherClient  *brewfather.Client
 
 	// Connected websocket clients
 	mu          sync.RWMutex
@@ -46,7 +50,7 @@ type WSMessage struct {
 }
 
 // NewServer initializes the WS/HTTP server and listens for OPC UA updates
-func NewServer(log zerolog.Logger, client *opcua.Client, fermentationStore fermentation.FermentationStore, engine *fermentation.Engine, brewhouseStore brewhouse.Store, brewhouseEngine *brewhouse.Engine) *Server {
+func NewServer(log zerolog.Logger, client *opcua.Client, fermentationStore fermentation.FermentationStore, engine *fermentation.Engine, brewhouseStore brewhouse.Store, brewhouseEngine *brewhouse.Engine, brewingEngine *brew.Engine, brewfatherClient *brewfather.Client) *Server {
 	s := &Server{
 		log:               log,
 		client:            client,
@@ -54,6 +58,8 @@ func NewServer(log zerolog.Logger, client *opcua.Client, fermentationStore ferme
 		engine:            engine,
 		brewhouseStore:    brewhouseStore,
 		brewhouseEngine:   brewhouseEngine,
+		brewingEngine:     brewingEngine,
+		brewfatherClient:  brewfatherClient,
 		subscribers:       make(map[*websocket.Conn]bool),
 		latest:            make(map[string]WSMessage),
 		upgrader: websocket.Upgrader{
@@ -69,6 +75,9 @@ func NewServer(log zerolog.Logger, client *opcua.Client, fermentationStore ferme
 	}
 	if s.brewhouseEngine != nil {
 		go s.broadcastBrewhouseState()
+	}
+	if s.brewingEngine != nil {
+		go s.broadcastBrewingStatus()
 	}
 	return s
 }
@@ -157,6 +166,13 @@ func (s *Server) Router() http.Handler {
 	r.Get("/api/glycol/status", s.handleGetGlycolStatus)
 	r.Get("/api/brewhouse/state", s.handleGetBrewhouseState)
 	r.Post("/api/brewhouse/state", s.handleUpdateBrewhouseState)
+
+	// Brewing process
+	r.Get("/api/brewfather/batches", s.handleListBrewfatherBatches)
+	r.Post("/api/brewing/start", s.handleStartBrewing)
+	// Fixed: Let's use handleStopBrewing
+	r.Post("/api/brewing/stop", s.handleStopBrewing)
+	r.Get("/api/brewing/status", s.handleGetBrewingStatus)
 
 	// ----------------------------------------------------
 	// STATIC FILES (INGENTING annet fjernes eller endres)

--- a/internal/api/ws_test.go
+++ b/internal/api/ws_test.go
@@ -153,7 +153,7 @@ func (m *MockFermentationStore) Close() error { return nil }
 
 func TestHealthCheckEndpoint(t *testing.T) {
 	log := logger.New()
-	server := NewServer(log, nil, &MockFermentationStore{}, nil, nil, nil)
+	server := NewServer(log, nil, &MockFermentationStore{}, nil, nil, nil, nil, nil)
 
 	req, err := http.NewRequest("GET", "/health", nil)
 	assert.NoError(t, err)
@@ -179,7 +179,7 @@ func TestSaveFermentationPlanEndpoint(t *testing.T) {
 			return 42, nil
 		},
 	}
-	server := NewServer(log, nil, mockStore, nil, nil, nil)
+	server := NewServer(log, nil, mockStore, nil, nil, nil, nil, nil)
 
 	plan := fermentation.FermentationPlan{
 		Name:     "Test Plan",
@@ -227,7 +227,7 @@ func TestListFermentationPlansEndpoint(t *testing.T) {
 			return expectedPlans, nil
 		},
 	}
-	server := NewServer(log, nil, mockStore, nil, nil, nil)
+	server := NewServer(log, nil, mockStore, nil, nil, nil, nil, nil)
 
 	req, err := http.NewRequest("GET", "/api/fermentation/plans", nil)
 	assert.NoError(t, err)
@@ -254,7 +254,7 @@ func TestStartFermentationEndpoint(t *testing.T) {
 			return []fermentation.FermentationState{{ID: 789}}, nil
 		},
 	}
-	server := NewServer(log, nil, mockStore, nil, nil, nil)
+	server := NewServer(log, nil, mockStore, nil, nil, nil, nil, nil)
 
 	reqBody := StartFermentationRequest{
 		PlanID: 123,
@@ -275,7 +275,7 @@ func TestStartFermentationEndpoint(t *testing.T) {
 
 func TestListTanksEndpoint(t *testing.T) {
 	log := logger.New()
-	server := NewServer(log, nil, &MockFermentationStore{}, nil, nil, nil)
+	server := NewServer(log, nil, &MockFermentationStore{}, nil, nil, nil, nil, nil)
 
 	req, err := http.NewRequest("GET", "/api/tanks", nil)
 	assert.NoError(t, err)
@@ -302,7 +302,7 @@ func TestDeleteFermentationPlanEndpoint(t *testing.T) {
 				return nil
 			},
 		}
-		server := NewServer(log, nil, mockStore, nil, nil, nil)
+		server := NewServer(log, nil, mockStore, nil, nil, nil, nil, nil)
 		req, _ := http.NewRequest("DELETE", "/api/fermentation/plan/123", nil)
 		rr := httptest.NewRecorder()
 		server.Router().ServeHTTP(rr, req)
@@ -315,7 +315,7 @@ func TestDeleteFermentationPlanEndpoint(t *testing.T) {
 				return fermentation.ErrPlanInUse
 			},
 		}
-		server := NewServer(log, nil, mockStore, nil, nil, nil)
+		server := NewServer(log, nil, mockStore, nil, nil, nil, nil, nil)
 		req, _ := http.NewRequest("DELETE", "/api/fermentation/plan/123", nil)
 		rr := httptest.NewRecorder()
 		server.Router().ServeHTTP(rr, req)
@@ -328,7 +328,7 @@ func TestDeleteFermentationPlanEndpoint(t *testing.T) {
 				return fermentation.ErrPlanNotFound
 			},
 		}
-		server := NewServer(log, nil, mockStore, nil, nil, nil)
+		server := NewServer(log, nil, mockStore, nil, nil, nil, nil, nil)
 		req, _ := http.NewRequest("DELETE", "/api/fermentation/plan/999", nil)
 		rr := httptest.NewRecorder()
 		server.Router().ServeHTTP(rr, req)
@@ -336,7 +336,7 @@ func TestDeleteFermentationPlanEndpoint(t *testing.T) {
 	})
 
 	t.Run("Invalid ID Format", func(t *testing.T) {
-		server := NewServer(log, nil, &MockFermentationStore{}, nil, nil, nil)
+		server := NewServer(log, nil, &MockFermentationStore{}, nil, nil, nil, nil, nil)
 		req, _ := http.NewRequest("DELETE", "/api/fermentation/plan/abc", nil)
 		rr := httptest.NewRecorder()
 		server.Router().ServeHTTP(rr, req)

--- a/internal/app/server.go
+++ b/internal/app/server.go
@@ -8,6 +8,8 @@ import (
 	"syscall"
 
 	"github.com/MrBoggi/goTOV/internal/api"
+	"github.com/MrBoggi/goTOV/internal/brew"
+	"github.com/MrBoggi/goTOV/internal/brewfather"
 	"github.com/MrBoggi/goTOV/internal/brewhouse"
 	"github.com/MrBoggi/goTOV/internal/config"
 	"github.com/MrBoggi/goTOV/internal/fermentation"
@@ -101,8 +103,18 @@ func RunServer(log zerolog.Logger) error {
 		defer brewhouseEngine.Stop()
 	}
 
+	// --- Brewing engine ---
+	brewingEngine := brew.NewEngine()
+
+	// --- Brewfather client for API proxy ---
+	var bfClient *brewfather.Client
+	if cfg.Brewfather.UserID != "" && cfg.Brewfather.APIKey != "" {
+		bfClient = brewfather.NewClient(cfg.Brewfather.UserID, cfg.Brewfather.APIKey)
+		log.Info().Msg("✅ Brewfather API client initialized")
+	}
+
 	// --- Start HTTP/WS API server ---
-	apiServer := api.NewServer(log, client, fermentationStore, engine, brewhouseStore, brewhouseEngine)
+	apiServer := api.NewServer(log, client, fermentationStore, engine, brewhouseStore, brewhouseEngine, brewingEngine, bfClient)
 	wg.Add(1)
 	go func() {
 		defer wg.Done()

--- a/internal/brew/session.go
+++ b/internal/brew/session.go
@@ -1,0 +1,44 @@
+package brew
+
+import (
+	"sync"
+	"time"
+)
+
+type BrewingSession struct {
+	ID            string        `json:"id"`
+	StartTime     time.Time     `json:"startTime"`
+	Status        string        `json:"status"` // "Manual" or "Brewfather"
+	BatchID       string        `json:"batchId,omitempty"`
+	RecipeName    string        `json:"recipeName"`
+	CurrentStep   string        `json:"currentStep"`
+	StepStartTime time.Time     `json:"stepStartTime"`
+	StepDuration  time.Duration `json:"stepDuration"`
+}
+
+type Engine struct {
+	mu      sync.RWMutex
+	session *BrewingSession
+}
+
+func NewEngine() *Engine {
+	return &Engine{}
+}
+
+func (e *Engine) StartSession(session *BrewingSession) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.session = session
+}
+
+func (e *Engine) StopSession() {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.session = nil
+}
+
+func (e *Engine) GetSession() *BrewingSession {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	return e.session
+}

--- a/internal/brew/tank.go
+++ b/internal/brew/tank.go
@@ -1,8 +1,0 @@
-package models
-
-type Tank struct {
-	Name        string
-	Temperature float64
-	Setpoint    float64
-	HeaterOn    bool
-}

--- a/internal/brewfather/parser.go
+++ b/internal/brewfather/parser.go
@@ -10,6 +10,22 @@ import (
 // 1) ENTRYPOINTS
 //
 
+// ExtractMashPlanFromBatch returns a list of mash steps from the batch.
+func ExtractMashPlanFromBatch(batch *BrewfatherBatch) ([]MashStep, error) {
+	if batch == nil {
+		return nil, fmt.Errorf("nil batch")
+	}
+	return batch.Recipe.Mash.Steps, nil
+}
+
+// ExtractBoilPlanFromBatch returns a list of boil steps from the batch.
+func ExtractBoilPlanFromBatch(batch *BrewfatherBatch) ([]BoilStep, error) {
+	if batch == nil {
+		return nil, fmt.Errorf("nil batch")
+	}
+	return batch.Recipe.Boil.Steps, nil
+}
+
 // ExtractFermentationPlan – legacy wrapper
 func ExtractFermentationPlan(recipe *BrewfatherRecipe) (*fermentation.FermentationPlan, error) {
 	return ExtractFermentationPlanFromRecipe(recipe)

--- a/internal/brewfather/types.go
+++ b/internal/brewfather/types.go
@@ -1,5 +1,22 @@
 package brewfather
 
+// MashStep represents a single mash step in a recipe.
+type MashStep struct {
+	Name     string  `json:"name"`
+	Type     string  `json:"type"`
+	StepTemp float64 `json:"stepTemp"`
+	StepTime float64 `json:"stepTime"` // minutes
+	RampTime float64 `json:"rampTime"` // minutes
+}
+
+// BoilStep represents an addition during the boil (hops, etc).
+type BoilStep struct {
+	Name        string  `json:"name"`
+	Type        string  `json:"type"`
+	Time        float64 `json:"time"` // minutes
+	Description string  `json:"description"`
+}
+
 // FermentationStep is how Brewfather represents a single fermentation step.
 // We support both the "old" style (time/temperature/timeUnit) and the
 // recipe-snapshot style (stepTemp/stepTime).
@@ -27,6 +44,12 @@ type BrewfatherRecipe struct {
 	ID           string                 `json:"_id"`
 	Name         string                 `json:"name"`
 	Fermentation BrewfatherFermentation `json:"fermentation"`
+	Mash         struct {
+		Steps []MashStep `json:"steps"`
+	} `json:"mash"`
+	Boil struct {
+		Steps []BoilStep `json:"steps"`
+	} `json:"boil"`
 }
 
 // BrewfatherBatch represents a Brewfather batch.

--- a/internal/brewhouse/engine_test.go
+++ b/internal/brewhouse/engine_test.go
@@ -9,7 +9,8 @@ import (
 )
 
 type mockStore struct {
-	state *BrewhouseState
+	state          *BrewhouseState
+	brewingSession string
 }
 
 func (m *mockStore) GetState() (*BrewhouseState, error) { return m.state, nil }
@@ -17,7 +18,13 @@ func (m *mockStore) SaveState(state *BrewhouseState) error {
 	m.state = state
 	return nil
 }
-func (m *mockStore) Close() error { return nil }
+func (m *mockStore) GetBrewingSession() (string, error) { return m.brewingSession, nil }
+func (m *mockStore) SaveBrewingSession(data string) error {
+	m.brewingSession = data
+	return nil
+}
+func (m *mockStore) LogBrewingSession(data string) error { return nil }
+func (m *mockStore) Close() error                        { return nil }
 
 func TestHeaterInterlock(t *testing.T) {
 	store := &mockStore{state: InitialState()}

--- a/internal/brewhouse/sqlite_store.go
+++ b/internal/brewhouse/sqlite_store.go
@@ -13,6 +13,9 @@ import (
 type Store interface {
 	GetState() (*BrewhouseState, error)
 	SaveState(state *BrewhouseState) error
+	GetBrewingSession() (string, error)
+	SaveBrewingSession(data string) error
+	LogBrewingSession(data string) error
 	Close() error
 }
 
@@ -48,6 +51,17 @@ func (s *SQLiteStore) migrate() error {
 CREATE TABLE IF NOT EXISTS brewhouse_state (
     id INTEGER PRIMARY KEY CHECK (id = 1),
     state_json TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS brewing_sessions (
+    id INTEGER PRIMARY KEY CHECK (id = 1),
+    session_json TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS brewing_logs (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_json TEXT NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 `
 	_, err := s.DB.Exec(schema)
@@ -100,6 +114,31 @@ func (s *SQLiteStore) SaveState(state *BrewhouseState) error {
 	_, err = s.DB.Exec("UPDATE brewhouse_state SET state_json = ? WHERE id = 1", string(data))
 	if err != nil {
 		return fmt.Errorf("update brewhouse state: %w", err)
+	}
+	return nil
+}
+
+func (s *SQLiteStore) GetBrewingSession() (string, error) {
+	var sessionJSON string
+	err := s.DB.Get(&sessionJSON, "SELECT session_json FROM brewing_sessions WHERE id = 1")
+	if err != nil {
+		return "", fmt.Errorf("get brewing session: %w", err)
+	}
+	return sessionJSON, nil
+}
+
+func (s *SQLiteStore) SaveBrewingSession(data string) error {
+	_, err := s.DB.Exec("INSERT INTO brewing_sessions (id, session_json) VALUES (1, ?) ON CONFLICT(id) DO UPDATE SET session_json = excluded.session_json", data)
+	if err != nil {
+		return fmt.Errorf("save brewing session: %w", err)
+	}
+	return nil
+}
+
+func (s *SQLiteStore) LogBrewingSession(data string) error {
+	_, err := s.DB.Exec("INSERT INTO brewing_logs (session_json) VALUES (?)", data)
+	if err != nil {
+		return fmt.Errorf("log brewing session: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
Implementerer backend-støtte for den nye bryggeprosessen, inkludert:
- Utvidet Brewfather-integrasjon (mash/boil)
- Brewing Engine for sesjonshåndtering
- Database-persistens for brygging
- API-endepunkter og WebSocket-kringkasting