### PR TITLE
feat: align fermentation history with fermentationId

### DIFF
--- a/internal/api/fermentation.go
+++ b/internal/api/fermentation.go
@@ -296,7 +296,7 @@ func (s *Server) handleGetFermentationHistory(w http.ResponseWriter, r *http.Req
 
 	history, err := s.fermentationStore.GetHistory(id, hours)
 	if err != nil {
-		s.log.Error().Err(err).Int64("planID", id).Msg("failed to fetch fermentation history")
+		s.log.Error().Err(err).Int64("fermentationId", id).Msg("failed to fetch fermentation history")
 		http.Error(w, "failed to fetch history", http.StatusInternalServerError)
 		return
 	}

--- a/internal/api/ws_test.go
+++ b/internal/api/ws_test.go
@@ -27,8 +27,8 @@ type MockFermentationStore struct {
 	GetStateByTankFunc          func(tankID string) (fermentation.FermentationState, error)
 	UpdateStateFunc             func(state fermentation.FermentationState) error
 	StopFermentationFunc        func(id int64) error
-	LogDataFunc                 func(planID int64, tankID string, batchID string, temp float32, target float32, valve bool, jacket bool) error
-	GetHistoryFunc              func(planID int64, hours float64) ([]fermentation.FermentationHistoryEntry, error)
+	LogDataFunc                 func(fermentationID int64, planID int64, tankID string, batchID string, temp float32, target float32, valve bool, jacket bool) error
+	GetHistoryFunc              func(fermentationID int64, hours float64) ([]fermentation.FermentationHistoryEntry, error)
 	LogGlycolDataFunc           func(temp float64, pressure *float64, load float64) error
 	GetGlycolHistoryFunc        func(hours float64) ([]fermentation.GlycolHistoryData, error)
 }
@@ -107,16 +107,16 @@ func (m *MockFermentationStore) StopFermentation(id int64) error {
 	return nil
 }
 
-func (m *MockFermentationStore) LogData(planID int64, tankID string, batchID string, temp float32, target float32, valve bool, jacket bool) error {
+func (m *MockFermentationStore) LogData(fermentationID int64, planID int64, tankID string, batchID string, temp float32, target float32, valve bool, jacket bool) error {
 	if m.LogDataFunc != nil {
-		return m.LogDataFunc(planID, tankID, batchID, temp, target, valve, jacket)
+		return m.LogDataFunc(fermentationID, planID, tankID, batchID, temp, target, valve, jacket)
 	}
 	return nil
 }
 
-func (m *MockFermentationStore) GetHistory(planID int64, hours float64) ([]fermentation.FermentationHistoryEntry, error) {
+func (m *MockFermentationStore) GetHistory(fermentationID int64, hours float64) ([]fermentation.FermentationHistoryEntry, error) {
 	if m.GetHistoryFunc != nil {
-		return m.GetHistoryFunc(planID, hours)
+		return m.GetHistoryFunc(fermentationID, hours)
 	}
 	return nil, nil
 }

--- a/internal/fermentation/engine.go
+++ b/internal/fermentation/engine.go
@@ -455,7 +455,7 @@ func (e *Engine) processOne(state *FermentationState) (bool, error) {
 		coolingActive = cooling
 
 		// Log to history
-		if err := e.store.LogData(state.PlanID, state.TankID, state.BatchID, currentTemp, target, cooling, heating); err != nil {
+		if err := e.store.LogData(state.ID, state.PlanID, state.TankID, state.BatchID, currentTemp, target, cooling, heating); err != nil {
 			e.log.Error().Err(err).Msg("failed to log fermentation history")
 		}
 	}

--- a/internal/fermentation/sqlite_store.go
+++ b/internal/fermentation/sqlite_store.go
@@ -78,6 +78,7 @@ CREATE TABLE IF NOT EXISTS fermentation_states (
 
 CREATE TABLE IF NOT EXISTS fermentation_history (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
+    fermentation_id INTEGER NOT NULL DEFAULT 0,
     plan_id INTEGER NOT NULL,
     tank_id TEXT NOT NULL,
     batch_id TEXT NOT NULL,
@@ -136,6 +137,15 @@ CREATE TABLE IF NOT EXISTS glycol_history (
 		_, err = s.DB.Exec("ALTER TABLE fermentation_states DROP COLUMN tank_no")
 		if err != nil {
 			return fmt.Errorf("failed to drop legacy tank_no column: %w", err)
+		}
+	}
+
+	// Check for fermentation_id column in fermentation_history
+	err = s.DB.Get(&count, "SELECT count(*) FROM pragma_table_info('fermentation_history') WHERE name='fermentation_id'")
+	if err == nil && count == 0 {
+		_, err = s.DB.Exec("ALTER TABLE fermentation_history ADD COLUMN fermentation_id INTEGER NOT NULL DEFAULT 0")
+		if err != nil {
+			return fmt.Errorf("failed to add fermentation_id column to history: %w", err)
 		}
 	}
 
@@ -272,25 +282,25 @@ WHERE id = :id`,
 	return err
 }
 
-func (s *SQLiteStore) LogData(planID int64, tankID string, batchID string, temp float32, target float32, valve bool, jacket bool) error {
+func (s *SQLiteStore) LogData(fermentationID int64, planID int64, tankID string, batchID string, temp float32, target float32, valve bool, jacket bool) error {
 	_, err := s.DB.Exec(`
 INSERT INTO fermentation_history 
-(plan_id, tank_id, batch_id, temperature, target_temp, cooling_valve, heating_jacket)
-VALUES (?, ?, ?, ?, ?, ?, ?)`,
-		planID, tankID, batchID, temp, target, valve, jacket)
+(fermentation_id, plan_id, tank_id, batch_id, temperature, target_temp, cooling_valve, heating_jacket)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		fermentationID, planID, tankID, batchID, temp, target, valve, jacket)
 	return err
 }
 
-func (s *SQLiteStore) GetHistory(planID int64, hours float64) ([]FermentationHistoryEntry, error) {
+func (s *SQLiteStore) GetHistory(fermentationID int64, hours float64) ([]FermentationHistoryEntry, error) {
 	var history []FermentationHistoryEntry
 	query := `
 		SELECT timestamp, temperature, target_temp, cooling_valve, heating_jacket 
 		FROM fermentation_history 
-		WHERE plan_id = ? 
+		WHERE fermentation_id = ? 
 		AND datetime(timestamp) >= datetime('now', '-' || ? || ' hours')
 		ORDER BY timestamp ASC`
 
-	err := s.DB.Select(&history, query, planID, hours)
+	err := s.DB.Select(&history, query, fermentationID, hours)
 	return history, err
 }
 

--- a/internal/fermentation/sqlite_store_test.go
+++ b/internal/fermentation/sqlite_store_test.go
@@ -1,0 +1,51 @@
+package fermentation
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSQLiteStore_HistoryFiltering(t *testing.T) {
+	dbPath := "test_fermentation.db"
+	defer os.Remove(dbPath)
+
+	store, err := NewSQLiteStore(dbPath)
+	require.NoError(t, err)
+	defer store.Close()
+
+	// 1. Create a plan and start two fermentations
+	planID, err := store.SavePlan(FermentationPlan{
+		Name:     "Test Plan",
+		RecipeID: "R1",
+		Steps: []FermentationStep{
+			{StepNumber: 1, Temperature: 20.0, DurationHours: 24},
+		},
+	})
+	require.NoError(t, err)
+
+	f1ID, err := store.StartFermentation(planID, "Tank1", "B1")
+	require.NoError(t, err)
+	f2ID, err := store.StartFermentation(planID, "Tank2", "B2")
+	require.NoError(t, err)
+
+	// 2. Log data for each (using different temperatures)
+	err = store.LogData(f1ID, planID, "Tank1", "B1", 19.0, 20.0, false, false)
+	assert.NoError(t, err)
+	err = store.LogData(f2ID, planID, "Tank2", "B2", 21.0, 20.0, true, false)
+	assert.NoError(t, err)
+
+	// 3. Verify history for f1 (should only have 19.0)
+	h1, err := store.GetHistory(f1ID, 24)
+	assert.NoError(t, err)
+	assert.Len(t, h1, 1)
+	assert.Equal(t, 19.0, h1[0].Temperature)
+
+	// 4. Verify history for f2 (should only have 21.0)
+	h2, err := store.GetHistory(f2ID, 24)
+	assert.NoError(t, err)
+	assert.Len(t, h2, 1)
+	assert.Equal(t, 21.0, h2[0].Temperature)
+}

--- a/internal/fermentation/store.go
+++ b/internal/fermentation/store.go
@@ -23,8 +23,8 @@ type FermentationStore interface {
 	GetStateByTank(tankID string) (FermentationState, error)
 	UpdateState(state FermentationState) error
 	StopFermentation(id int64) error
-	LogData(planID int64, tankID string, batchID string, temp float32, target float32, valve bool, jacket bool) error
-	GetHistory(planID int64, hours float64) ([]FermentationHistoryEntry, error)
+	LogData(fermentationID int64, planID int64, tankID string, batchID string, temp float32, target float32, valve bool, jacket bool) error
+	GetHistory(fermentationID int64, hours float64) ([]FermentationHistoryEntry, error)
 	LogGlycolData(temp float64, pressure *float64, load float64) error
 	GetGlycolHistory(hours float64) ([]GlycolHistoryData, error)
 	Clear() error


### PR DESCRIPTION
This PR aligns the fermentation history endpoint with the frontend's requirements by filtering by the unique fermentation instance ID (fermentationId) instead of the plan ID. This prevents temperature data from different tanks using the same plan from being mixed up in graphs.