### PR TITLE
fix: prevent duplicate active fermentation per tank

### DIFF
--- a/internal/api/fermentation.go
+++ b/internal/api/fermentation.go
@@ -78,6 +78,10 @@ func (s *Server) handleStartFermentation(w http.ResponseWriter, r *http.Request)
 
 	fermentationID, err := s.fermentationStore.StartFermentation(req.PlanID, req.TankID, req.BatchID)
 	if err != nil {
+		if errors.Is(err, fermentation.ErrTankBusy) {
+			http.Error(w, "tank already has an active fermentation running — stop it first", http.StatusConflict)
+			return
+		}
 		s.log.Error().Err(err).Msg("failed to start fermentation in store")
 		http.Error(w, "failed to start fermentation", http.StatusInternalServerError)
 		return

--- a/internal/fermentation/sqlite_store.go
+++ b/internal/fermentation/sqlite_store.go
@@ -252,6 +252,16 @@ func (s *SQLiteStore) ListPlans() ([]FermentationPlan, error) {
 }
 
 func (s *SQLiteStore) StartFermentation(planID int64, tankID string, batchID string) (int64, error) {
+	// Hard block: A tank can only run ONE fermentation at a time.
+	var existingCount int
+	err := s.DB.Get(&existingCount, "SELECT COUNT(*) FROM fermentation_states WHERE tank_id = ? AND status = ?", tankID, StatusRunning)
+	if err != nil {
+		return 0, fmt.Errorf("check for existing active fermentation on tank %s: %w", tankID, err)
+	}
+	if existingCount > 0 {
+		return 0, ErrTankBusy
+	}
+
 	steps, err := s.GetSteps(planID)
 	if err != nil || len(steps) == 0 {
 		return 0, fmt.Errorf("get steps for starting fermentation: %w", err)

--- a/internal/fermentation/store.go
+++ b/internal/fermentation/store.go
@@ -9,6 +9,7 @@ var (
 	ErrPlanNotFound         = errors.New("fermentation plan not found")
 	ErrFermentationNotFound = errors.New("active fermentation not found")
 	ErrEventNotFound        = errors.New("event not found")
+	ErrTankBusy             = errors.New("tank already has an active fermentation running")
 )
 
 type FermentationStore interface {


### PR DESCRIPTION
## Problem

Two concurrent fermentations were allowed on the same tank (Tank 1), causing conflicting thermostat decisions. The engine processed both states and cooled the tank toward the lower setpoint (17.4C) while the UI displayed the intended setpoint (28.0C).

## Root Cause

StartFermentation had no guard against starting a second fermentation on a tank that was already RUNNING. This allowed ErrTankBusy situation to silently occur.

## Changes

- **store.go**: Added ErrTankBusy sentinel error.
- **sqlite_store.go**: StartFermentation now checks for an existing RUNNING state on the target tank and returns ErrTankBusy immediately if one is found.
- **pi/fermentation.go**: handleStartFermentation returns **HTTP 409 Conflict** with a clear message when the tank is busy.

## Testing

- go build ./... ✅
- golangci-lint run ./... ✅ 
- go test ./... ✅ (all packages pass)

## Immediate Remediation

The rogue fermentation (ID 33, FWK Pilsner at 17.4C) was stopped directly via API on the live server (192.168.10.115) while this fix was being developed.

Closes: #(ghost-cooling-tank1)