### PR TITLE
feat: Local/Remote control gjæringsprosess (#60)

### DIFF
--- a/internal/api/fermentation.go
+++ b/internal/api/fermentation.go
@@ -26,6 +26,11 @@ type CompleteFermentationEventRequest struct {
 	EventIndex     int   `json:"eventIndex"`
 }
 
+type SetFermentationModeRequest struct {
+	ID   int64  `json:"id"`
+	Mode string `json:"mode"`
+}
+
 func (s *Server) handleSaveFermentationPlan(w http.ResponseWriter, r *http.Request) {
 	var plan fermentation.FermentationPlan
 	if err := json.NewDecoder(r.Body).Decode(&plan); err != nil {
@@ -161,6 +166,49 @@ func (s *Server) handleCompleteFermentationEvent(w http.ResponseWriter, r *http.
 		http.Error(w, "failed to complete event", http.StatusInternalServerError)
 		return
 	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{"status": "ok"})
+}
+
+func (s *Server) handleSetFermentationMode(w http.ResponseWriter, r *http.Request) {
+	var req SetFermentationModeRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		s.log.Error().Err(err).Msg("failed to decode set fermentation mode request")
+		http.Error(w, "invalid JSON", http.StatusBadRequest)
+		return
+	}
+
+	if req.Mode != "Auto" && req.Mode != "Manual" {
+		http.Error(w, "mode must be Auto or Manual", http.StatusBadRequest)
+		return
+	}
+
+	state, err := s.fermentationStore.GetState(req.ID)
+	if err != nil {
+		s.log.Error().Err(err).Int64("id", req.ID).Msg("failed to get fermentation state for mode change")
+		http.Error(w, "fermentation not found", http.StatusNotFound)
+		return
+	}
+
+	state.Mode = req.Mode
+	if err := s.fermentationStore.UpdateState(state); err != nil {
+		s.log.Error().Err(err).Int64("id", req.ID).Msg("failed to update fermentation mode")
+		http.Error(w, "failed to update mode", http.StatusInternalServerError)
+		return
+	}
+
+	// Update in engine if active
+	if s.engine != nil {
+		// Just pull from engine to modify, then we don't need a formal method if it's already there or we can just update the DB and let the engine read it?
+		// Engine stores state pointers, so we could theoretically modify the pointer directly, but we don't have direct access in api.
+		// Since we updated the DB, next processOne would use old state pointer because engine holds it in memory.
+		// Wait, Engine needs a method to update the mode in memory.
+		s.engine.UpdateFermentationMode(req.ID, req.Mode)
+	}
+
+	s.log.Info().Int64("id", req.ID).Str("mode", req.Mode).Msg("🔄 Fermentation mode updated")
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)

--- a/internal/api/ws.go
+++ b/internal/api/ws.go
@@ -213,6 +213,7 @@ func (s *Server) Router() http.Handler {
 	r.Post("/api/fermentation/start", s.handleStartFermentation)
 	r.Post("/api/fermentation/stop", s.handleStopFermentation)
 	r.Post("/api/fermentation/event/complete", s.handleCompleteFermentationEvent)
+	r.Post("/api/fermentation/mode", s.handleSetFermentationMode)
 	r.Get("/api/fermentation/status", s.handleGetFermentationStatus)
 	r.Get("/api/fermentation/history/{id}", s.handleGetFermentationHistory)
 	r.Get("/api/fermentation/docs", s.handleGetApiDocs)

--- a/internal/fermentation/engine.go
+++ b/internal/fermentation/engine.go
@@ -166,6 +166,16 @@ func (e *Engine) RemoveFermentation(id int64) {
 	e.log.Info().Int64("id", id).Msg("➖ Removed fermentation from engine map")
 }
 
+// UpdateFermentationMode modifies the mode of an active fermentation in memory.
+func (e *Engine) UpdateFermentationMode(id int64, mode string) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if state, ok := e.active[id]; ok {
+		state.Mode = mode
+		e.log.Info().Int64("id", id).Str("mode", mode).Msg("🔄 Updated mode in engine memory")
+	}
+}
+
 // GetActiveStates returns a snapshot of all active fermentation states
 // including computed fields like Transitioning.
 func (e *Engine) GetActiveStates() []FermentationState {
@@ -615,47 +625,88 @@ func (e *Engine) processOne(state *FermentationState) (bool, error) {
 		}
 
 		// 4. Update Thermostat States based on currentTemp
-		// Cooling logic: Start if > target + 0.2, stop if <= target
-		// Heating logic: Start if < target - 0.2, stop if >= target
-
 		valveTag := fmt.Sprintf("ns=4;s=MAIN.fbUA.fermenter%sKjoleventil", state.TankID)
 		jacketTag := fmt.Sprintf("ns=4;s=MAIN.fbUA.fermenter%sVarmekappe", state.TankID)
 
-		// Get last known states to implement the "stop at target" logic
-		e.mu.RLock()
-		lastCooling, _ := e.lastWritten[valveTag].(bool)
-		lastHeating, _ := e.lastWritten[jacketTag].(bool)
-		e.mu.RUnlock()
+		if state.Mode == "Manual" {
+			// MANUAL MODE: Do not touch hardware, but read state to log and orchestrate glycol pump
+			val, err := e.client.ReadNodeValue(ctx, valveTag)
+			if err == nil {
+				if b, ok := val.(bool); ok {
+					coolingActive = b
+					// Sync to engine so pump logic knows cooling is demanded
+					e.seqMu.Lock()
+					e.desiredValves[state.TankID] = b
+					e.actualValves[state.TankID] = b
+					e.seqMu.Unlock()
 
-		if currentTemp > target+hysteresis {
-			cooling = true
-		} else if currentTemp > target {
-			cooling = lastCooling // Stay on if already cooling, but don't start
-		}
+					e.mu.Lock()
+					e.lastWritten[valveTag] = b
+					e.mu.Unlock()
+				}
+			}
 
-		if currentTemp < target-hysteresis {
-			heating = true
-		} else if currentTemp < target {
-			heating = lastHeating // Stay on if already heating, but don't start
-		}
+			heatingActive := false
+			valH, errH := e.client.ReadNodeValue(ctx, jacketTag)
+			if errH == nil {
+				if b, ok := valH.(bool); ok {
+					heatingActive = b
+					e.mu.Lock()
+					e.lastWritten[jacketTag] = b
+					e.mu.Unlock()
+				}
+			}
 
-		e.log.Debug().
-			Str("tank", state.TankID).
-			Float32("current", currentTemp).
-			Float32("target", target).
-			Bool("cooling", cooling).
-			Bool("heating", heating).
-			Bool("lastCooling", lastCooling).
-			Bool("lastHeating", lastHeating).
-			Bool("transitioning", state.Transitioning).
-			Msg("🌡️ Thermostat decision")
+			e.log.Debug().
+				Str("tank", state.TankID).
+				Float32("current", currentTemp).
+				Float32("target", target).
+				Bool("cooling", coolingActive).
+				Bool("heating", heatingActive).
+				Msg("🌡️ Mode is Manual - skipping hardware control")
 
-		e.setTankHardware(state.TankID, cooling, heating)
-		coolingActive = cooling
+			// Log to history
+			if err := e.store.LogData(state.ID, state.PlanID, state.TankID, state.BatchID, currentTemp, target, coolingActive, heatingActive); err != nil {
+				e.log.Error().Err(err).Msg("failed to log fermentation history for manual mode")
+			}
+		} else {
+			// AUTO MODE
+			// Get last known states to implement the "stop at target" logic
+			e.mu.RLock()
+			lastCooling, _ := e.lastWritten[valveTag].(bool)
+			lastHeating, _ := e.lastWritten[jacketTag].(bool)
+			e.mu.RUnlock()
 
-		// Log to history
-		if err := e.store.LogData(state.ID, state.PlanID, state.TankID, state.BatchID, currentTemp, target, cooling, heating); err != nil {
-			e.log.Error().Err(err).Msg("failed to log fermentation history")
+			if currentTemp > target+hysteresis {
+				cooling = true
+			} else if currentTemp > target {
+				cooling = lastCooling // Stay on if already cooling, but don't start
+			}
+
+			if currentTemp < target-hysteresis {
+				heating = true
+			} else if currentTemp < target {
+				heating = lastHeating // Stay on if already heating, but don't start
+			}
+
+			e.log.Debug().
+				Str("tank", state.TankID).
+				Float32("current", currentTemp).
+				Float32("target", target).
+				Bool("cooling", cooling).
+				Bool("heating", heating).
+				Bool("lastCooling", lastCooling).
+				Bool("lastHeating", lastHeating).
+				Bool("transitioning", state.Transitioning).
+				Msg("🌡️ Thermostat decision")
+
+			e.setTankHardware(state.TankID, cooling, heating)
+			coolingActive = cooling
+
+			// Log to history
+			if err := e.store.LogData(state.ID, state.PlanID, state.TankID, state.BatchID, currentTemp, target, cooling, heating); err != nil {
+				e.log.Error().Err(err).Msg("failed to log fermentation history for auto mode")
+			}
 		}
 	}
 

--- a/internal/fermentation/sqlite_store.go
+++ b/internal/fermentation/sqlite_store.go
@@ -161,6 +161,15 @@ CREATE TABLE IF NOT EXISTS active_fermentation_events (
 		}
 	}
 
+	// Check for mode column in fermentation_states
+	err = s.DB.Get(&count, "SELECT count(*) FROM pragma_table_info('fermentation_states') WHERE name='mode'")
+	if err == nil && count == 0 {
+		_, err = s.DB.Exec("ALTER TABLE fermentation_states ADD COLUMN mode TEXT NOT NULL DEFAULT 'Auto'")
+		if err != nil {
+			return fmt.Errorf("failed to add mode column: %w", err)
+		}
+	}
+
 	// Check for fermentation_id column in fermentation_history
 	err = s.DB.Get(&count, "SELECT count(*) FROM pragma_table_info('fermentation_history') WHERE name='fermentation_id'")
 	if err == nil && count == 0 {
@@ -277,12 +286,13 @@ func (s *SQLiteStore) StartFermentation(planID int64, tankID string, batchID str
 		StepStartedAt: now,
 		TargetTemp:    steps[0].Temperature,
 		Status:        StatusRunning,
+		Mode:          "Auto",
 		StepActive:    false,
 	}
 
 	res, err := s.DB.NamedExec(`
-INSERT INTO fermentation_states (plan_id, tank_id, batch_id, step_index, started_at, step_started_at, target_temp, status, step_active)
-VALUES (:plan_id, :tank_id, :batch_id, :step_index, :started_at, :step_started_at, :target_temp, :status, :step_active)`,
+INSERT INTO fermentation_states (plan_id, tank_id, batch_id, step_index, started_at, step_started_at, target_temp, status, mode, step_active)
+VALUES (:plan_id, :tank_id, :batch_id, :step_index, :started_at, :step_started_at, :target_temp, :status, :mode, :step_active)`,
 		state)
 	if err != nil {
 		return 0, fmt.Errorf("insert fermentation state: %w", err)
@@ -373,7 +383,7 @@ func (s *SQLiteStore) StopFermentation(id int64) error {
 func (s *SQLiteStore) UpdateState(state FermentationState) error {
 	_, err := s.DB.NamedExec(`
 UPDATE fermentation_states 
-SET step_index = :step_index, step_started_at = :step_started_at, target_temp = :target_temp, status = :status, step_active = :step_active
+SET step_index = :step_index, step_started_at = :step_started_at, target_temp = :target_temp, status = :status, mode = :mode, step_active = :step_active
 WHERE id = :id`,
 		state)
 	return err

--- a/internal/fermentation/types.go
+++ b/internal/fermentation/types.go
@@ -111,6 +111,7 @@ type FermentationState struct {
 	StepDuration  float64                   `db:"-" json:"stepDuration,omitempty"`
 	TargetTemp    float64                   `db:"target_temp" json:"targetTemp"`
 	Status        string                    `db:"status" json:"status"`
+	Mode          string                    `db:"mode" json:"mode"`
 	Transitioning bool                      `db:"-" json:"transitioning"`
 	StepActive    bool                      `db:"step_active" json:"stepActive"`
 	Events        []ActiveFermentationEvent `db:"-" json:"events,omitempty"`


### PR DESCRIPTION
Resolve #60

* La til Mode i FermentationState (Auto/Manual)
* La til API endpoint `/api/fermentation/mode`
* Oppdatert engine logikk: Hopper over overstyring av ventiler og varmekappe dersom tanken er i Manual modus, men leser verdier ifra OPC for historie/logging.
* Gjæringstidsporing fortsetter som normalt uansett modus.