### PR TITLE
fix(api): allow PUT method in CORS policy

### DIFF
--- a/internal/api/ws.go
+++ b/internal/api/ws.go
@@ -178,7 +178,7 @@ func (s *Server) Router() http.Handler {
 
 	r.Use(cors.Handler(cors.Options{
 		AllowedOrigins:   []string{"*"},
-		AllowedMethods:   []string{"GET", "POST", "DELETE", "OPTIONS"},
+		AllowedMethods:   []string{"GET", "POST", "PUT", "DELETE", "OPTIONS"},
 		AllowedHeaders:   []string{"Accept", "Authorization", "Content-Type", "X-CSRF-Token"},
 		AllowCredentials: false,
 		MaxAge:           300,


### PR DESCRIPTION
## Beskrivelse
Denne PR-en fikser en CORS-feil som hindret frontend i å oppdatere gjæringsplaner og aktive trinn.

### Endringer
- Lagt til \PUT\ i \AllowedMethods\ i CORS-middleware i \internal/api/ws.go\.

### Verifisering
- Enhetstester og linting kjørt uten feil.
- Bekrefter at preflight (OPTIONS) vil tillate PUT-forespørsler.